### PR TITLE
Fix cannot insert row with no insert parameter

### DIFF
--- a/SqlNado.Tests/Database.cs
+++ b/SqlNado.Tests/Database.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SqlNado.Tests
@@ -8,7 +9,92 @@ namespace SqlNado.Tests
         [TestMethod]
         public void CreateDatase()
         {
-            //var db = new SQLiteDatabase();
+            using (var db = new SQLiteDatabase(":memory:"))
+            {
+                db.Save(new Customer1());
+
+                var table = db.GetTable("Customer");
+                Assert.AreEqual(2, table.Columns.Count);
+                Assert.AreEqual(nameof(SQLiteColumnType.INTEGER), table.GetColumn("Id").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("Name").Type);
+            }
+        }
+
+        [TestMethod]
+        public void SchemaMigration_PreserveUnusedColumns()
+        {
+            using (var db = new SQLiteDatabase(":memory:"))
+            {
+                db.SynchronizeSchema<Customer1>();
+                var table = db.GetTable("Customer");
+                Assert.AreEqual(nameof(SQLiteColumnType.INTEGER), table.GetColumn("Id").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("Name").Type);
+
+                db.SynchronizeSchema<Customer2>();
+                table = db.GetTable("Customer");
+                Assert.AreEqual(4, table.Columns.Count);
+                Assert.AreEqual(nameof(SQLiteColumnType.INTEGER), table.GetColumn("Id").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("Name").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("FirstName").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("LastName").Type);
+            }
+        }
+
+        [TestMethod]
+        public void SchemaMigration_DeleteUnusedColumns()
+        {
+            using (var db = new SQLiteDatabase(":memory:"))
+            {
+                db.SynchronizeSchema<Customer1>();
+                var table = db.GetTable("Customer");
+                Assert.AreEqual(nameof(SQLiteColumnType.INTEGER), table.GetColumn("Id").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("Name").Type);
+
+                var saveOptions = db.CreateSaveOptions();
+                saveOptions.DeleteUnusedColumns = true;
+                db.SynchronizeSchema<Customer2>(saveOptions);
+                table = db.GetTable("Customer");
+                Assert.AreEqual(3, table.Columns.Count);
+                Assert.AreEqual(nameof(SQLiteColumnType.INTEGER), table.GetColumn("Id").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("FirstName").Type);
+                Assert.AreEqual(nameof(SQLiteColumnType.TEXT), table.GetColumn("LastName").Type);
+            }
+        }
+
+        [TestMethod]
+        public void SchemaMigration_PreserveValues()
+        {
+            using (var db = new SQLiteDatabase(":memory:"))
+            {
+                db.Save(new Customer1 { Id = 1, Name = "Row1" });
+                db.SynchronizeSchema<Customer3>();
+
+                var customer = db.LoadAll<Customer3>().Single();
+                Assert.AreEqual("1", customer.Id);
+                Assert.AreEqual("Row1", customer.Name);
+            }
+        }
+
+        [SQLiteTable(Name = "Customer")]
+        private class Customer1
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [SQLiteTable(Name = "Customer")]
+        private class Customer2
+        {
+            public int Id { get; set; }
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+        }
+
+        [SQLiteTable(Name = "Customer")]
+        private class Customer3
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
         }
     }
 }

--- a/SqlNado.Tests/GeneratedValues.cs
+++ b/SqlNado.Tests/GeneratedValues.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SqlNado.Tests
+{
+    [TestClass]
+    public class GeneratedValues
+    {
+        [TestMethod]
+        public void AutomaticColumn_AutoIncrement()
+        {
+            using (var db = new SQLiteDatabase(":memory:"))
+            {
+                db.Save(new AutoIncrement());
+                db.Save(new AutoIncrement());
+                db.Save(new AutoIncrement());
+
+                var customers = db.LoadAll<AutoIncrement>();
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, customers.Select(c => c.Id).ToList());
+            }
+        }
+
+        internal class AutoIncrement
+        {
+            [SQLiteColumn(IsPrimaryKey = true, AutoIncrements = true)]
+            public int Id { get; set; }
+        }
+    }
+}

--- a/SqlNado.Tests/SqlNado.Tests.csproj
+++ b/SqlNado.Tests/SqlNado.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SqlNado.sln
+++ b/SqlNado.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlNado.Temp", "SqlNado.Tem
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlNado.Cli", "SqlNado.Cli\SqlNado.Cli.csproj", "{D184B8AF-6BC4-4E8E-9BE5-F4519374F04B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlNado.Tests", "SqlNado.Tests\SqlNado.Tests.csproj", "{48CADD57-A74C-45CA-B727-801CD00A9C5C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{D184B8AF-6BC4-4E8E-9BE5-F4519374F04B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D184B8AF-6BC4-4E8E-9BE5-F4519374F04B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D184B8AF-6BC4-4E8E-9BE5-F4519374F04B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48CADD57-A74C-45CA-B727-801CD00A9C5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48CADD57-A74C-45CA-B727-801CD00A9C5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48CADD57-A74C-45CA-B727-801CD00A9C5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48CADD57-A74C-45CA-B727-801CD00A9C5C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SqlNado/SQLiteObjectTable.cs
+++ b/SqlNado/SQLiteObjectTable.cs
@@ -419,8 +419,22 @@ namespace SqlNado
 
                 if (count == 0)
                 {
-                    sql = "INSERT " + GetConflictResolutionClause(options.ConflictResolution) + "INTO " + EscapedName + " (" + BuildColumnsInsertStatement();
-                    sql += ") VALUES (" + BuildColumnsInsertParametersStatement() + ")";
+                    var columnsInsertStatement = BuildColumnsInsertStatement();
+                    var columnsInsertParametersStatement = BuildColumnsInsertParametersStatement();
+                    sql = "INSERT " + GetConflictResolutionClause(options.ConflictResolution) + "INTO " + EscapedName;
+                    if (!string.IsNullOrEmpty(columnsInsertStatement))
+                    {
+                        sql += " (" + columnsInsertStatement + ")";
+                    }
+
+                    if (string.IsNullOrEmpty(columnsInsertParametersStatement))
+                    {
+                        sql += " DEFAULT VALUES";
+                    }
+                    else
+                    {
+                        sql += " VALUES (" + BuildColumnsInsertParametersStatement() + ")";
+                    }
 
                     Func<SQLiteError, SQLiteOnErrorAction> onError = (e) =>
                     {


### PR DESCRIPTION
SQLNado generates an invalid insert statement when there is no insert parameter. This can happen when all columns are computed.

    INSERT INTO Customer () VALUES ()

This PR changes the SQL statement to

    INSERT INTO Customer DEFAULT VALUES

BTW, I've added the test project to the solution and a few tests.